### PR TITLE
Added support for negative integers

### DIFF
--- a/lib/php_serialization/tokenizer.rb
+++ b/lib/php_serialization/tokenizer.rb
@@ -7,7 +7,7 @@ module PhpSerialization
     def each
       while !@string.empty?
         token = case @string
-        when /\A[0-9]+(\.[0-9]+)?/m then yield([:NUMBER, $&])
+        when /\A-?[0-9]+(\.[0-9]+)?/m then yield([:NUMBER, $&])
         when /\A"([^"]*)"/m         then yield([:STRING, $1])
         when /\A[^\s]/m             then yield([$&, $&])
         end


### PR DESCRIPTION
The following currently fails: PhpSerialization.load(PhpSerialization.dump(-1))

I tweaked the regular expression in the Tokenizer class to allow an optional negative sign for NUMBERs.
