### PR TITLE
Fix serializing multibyte character length issue.

### DIFF
--- a/lib/php_serialization/serializer.rb
+++ b/lib/php_serialization/serializer.rb
@@ -13,7 +13,7 @@ module PhpSerialization
       when Float then
         "d:#{object};"
       when String, Symbol then
-        "s:#{object.to_s.length}:\"#{object}\";"
+        "s:#{object.to_s.bytesize}:\"#{object}\";"
       when Array then
         idx   = -1
         items = object.map { |item| "#{run(idx += 1)}#{run(item)}" }.join
@@ -23,14 +23,14 @@ module PhpSerialization
         "a:#{object.length}:{#{items}}"
       else
         klass_name = object.class.name
-        
+
         if klass_name =~ /^Struct::/ && php_klass = object.instance_variable_get("@_php_class")
           klass_name = php_klass
         end
-        
+
         attributes = object.instance_variables.map { |var_name| "#{run(var_name.gsub(/^@/, ''))}#{run(object.instance_variable_get(var_name))}" }
         "O:#{klass_name.length}:\"#{klass_name}\":#{object.instance_variables.length}:{#{attributes}}"
       end
-    end  
+    end
   end
 end


### PR DESCRIPTION
When developer serialize multibyte character, it seems serialized, but unserialize it through php fails. It is because php serialization expects sting byte length, but `String#length` is just length of string in ruby >= 1.9.
To fix the issue, changed to use `String#bytesize` in `Serializer#run`.